### PR TITLE
Update HTML links to use lowercase filenames

### DIFF
--- a/issues.html
+++ b/issues.html
@@ -394,7 +394,7 @@
                     
                   >
                     <a
-                      href="MentalAbuse.html"
+                      href="mental-abuse.html"
                       class="text-uppercase text-primary fw-light"
                       ><span
                         class="lang-toggle"
@@ -406,7 +406,7 @@
                     <span class="tooltip-text">Emotional harm caused by manipulation, threats, or constant criticism</span>
                    
                     <h5 class="card-title mt-2">
-                      <a href="MentalAbuse.html"
+                      <a href="mental-abuse.html"
                         ><span
                           class="lang-toggle"
                           data-en="Empower Yourself, Know the Signs"
@@ -431,9 +431,9 @@
                 />
                 <div class="card-body">
                   <span class="tooltip-parent" >
-                                  <a href="WorkplaceHarrassment.html" class="text-uppercase text-primary fw-light"><span class="lang-toggle" data-en="Workplace Harassment" data-hi="[कार्यस्थल उत्पीड़न]">Workplace Harassment</span></a>
+                                  <a href="workplace-harrassment.html" class="text-uppercase text-primary fw-light"><span class="lang-toggle" data-en="Workplace Harassment" data-hi="[कार्यस्थल उत्पीड़न]">Workplace Harassment</span></a>
                                   <span class="tooltip-text">Unwanted behaviour at work that makes someone feel unsafe or disrespected</span>
-                                  <h5 class="card-title mt-2"><a href="WorkplaceHarrassment.html"><span class="lang-toggle" data-en="Ensure respect" data-hi="[सम्मान सुनिश्चित करें]">Ensure respect</span></a></h5>
+                                  <h5 class="card-title mt-2"><a href="workplace-harrassment.html"><span class="lang-toggle" data-en="Ensure respect" data-hi="[सम्मान सुनिश्चित करें]">Ensure respect</span></a></h5>
                               </span>
                 </div>
               </div>
@@ -534,7 +534,7 @@
                     
                   >
                     <a
-                      href="coupleTherapy.html"
+                      href="couple-therapy.html"
                       class="text-uppercase text-primary fw-light"
                       ><span
                         class="lang-toggle"
@@ -545,7 +545,7 @@
                     >
                     <span class="tooltip-text">Guided sessions that help partners communicate and solve relationship issues</span>
                     <h5 class="card-title mt-2">
-                      <a href="coupleTherapy.html"
+                      <a href="couple-therapy.html"
                         ><span
                           class="lang-toggle"
                           data-en="Reconnect & Strengthen Your Bond"


### PR DESCRIPTION
Some pages like Mental Abuse, Workplace Harassment and couples therapy were not accessible. Linked them to correct filenames.

https://github.com/user-attachments/assets/67444ba5-2084-4935-bf69-03d0a7dd77e5

